### PR TITLE
fix: 去除侧边栏菜单 padding-top

### DIFF
--- a/src/layout/sidebar/index.vue
+++ b/src/layout/sidebar/index.vue
@@ -1,6 +1,6 @@
 <template>
   <a-menu
-    :style="{ width: '220px', height: '100%', flexShrink: 0, paddingTop: '50px' }"
+    :style="{ width: '220px', height: '100%', flexShrink: 0 }"
     :default-selected-keys="[openedMenu]"
     :auto-open="true"
     @menu-item-click="to"


### PR DESCRIPTION
个人认为这个侧边栏菜单 `padding-top` 不太美观

**改动前**
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/48596931/179542016-495434cd-d542-4190-87f9-4d5dcc3b8991.png">

**改动后**
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/48596931/179541651-93c3ae8a-039c-407a-b781-8d9bf2e794c2.png">

**改动文件**
src/layout/sidebar/index.vue